### PR TITLE
feat: Run Linter before commit by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "chimp-watch": "chimp --ddp=http://localhost:3000 --watch --mocha --path=tests",
     "chimp-test": "chimp --ddp=http://localhost:3000 --mocha --path=tests --webdriverio.waitforTimeout=5000"
   },
-  "pre-commit":[
+  "pre-commit": [
     "lint-fix"
   ],
   "dependencies": {
@@ -50,6 +50,7 @@
     "ethereumjs-testrpc": "^4.0.1",
     "mocha": "^3.4.1",
     "nightmare": "^2.10.0",
+    "pre-commit": "^1.2.2",
     "shell-source": "^1.1.0",
     "shelljs": "^0.7.8"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "chimp-watch": "chimp --ddp=http://localhost:3000 --watch --mocha --path=tests",
     "chimp-test": "chimp --ddp=http://localhost:3000 --mocha --path=tests --webdriverio.waitforTimeout=5000"
   },
+  "pre-commit":[
+    "lint-fix"
+  ],
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "bcrypt": "^1.0.2",


### PR DESCRIPTION
Hey @jellegerbrandy , This PR adds a git pre-commit hook to run `npm run lint-fix` before commits. This bad code won't get committed and refixed later.

although discouraged, you can always ignore the pre-commit hook by adding `-n` to your commit command `git commit -n`