### PR TITLE
relative path for IPFS build

### DIFF
--- a/imports/lib/ipfs/index.js
+++ b/imports/lib/ipfs/index.js
@@ -17,7 +17,7 @@ function initIPFS (callback) {
       cache: true
     })
     // $.getScript('https://unpkg.com/ipfs@0.25.4/dist/index.js', () => {
-    $.getScript('http://localhost:3000/test/files/index.js', () => {
+    $.getScript('/test/files/index.js', () => {
     // $.getScript('./ipfs0.25.1.js', () => {
       // console.log('Ipfs: ', Ipfs)
       // const wstar = new WebRTCStar()


### PR DESCRIPTION
@jellegerbrandy This is a fix for the issue you raised regarding the use of `http://localhost:3000` in the script.