### PR TITLE
Ipfs/protocol initial integration

### DIFF
--- a/imports/lib/ipfs/index.js
+++ b/imports/lib/ipfs/index.js
@@ -1,11 +1,14 @@
 /* globals Ipfs */
 'use strict'
 import { Meteor } from 'meteor/meteor'
+import { getUserPTIAddress } from '/imports/api/users.js'
+import Protocol from 'paratii-protocol'
 
 const REPO_PATH = 'paratii-ipfs-repo'
 function noop () {}
 
 const paratiiIPFS = {
+  protocol: null,
   /**
   * initIPFS - initiates Ipfs instance
   *
@@ -107,7 +110,17 @@ const paratiiIPFS = {
           window.ipfs.id().then((id) => {
             let peerInfo = id
             console.log('[IPFS] id: ', peerInfo)
-            callback()
+            let ptiAddress = getUserPTIAddress() || 'no_address'
+            paratiiIPFS.protocol = new Protocol(
+              window.ipfs._libp2pNode,
+              window.ipfs._repo.blocks,
+              // add ETH Address here.
+              ptiAddress
+            )
+
+            paratiiIPFS.protocol.start(callback)
+
+            // callback()
           })
         })
 

--- a/imports/ui/pages/player/ipfs.js
+++ b/imports/ui/pages/player/ipfs.js
@@ -99,6 +99,13 @@ export function createIPFSPlayer (templateInstance, currentVideo) {
     })
 
     paratiiIPFS.initIPFS(() => {
+
+      paratiiIPFS.protocol.notifications.on('message:new', (peerId, msg) => {
+        if (msg && msg.hello) {
+          console.log('[PROTOCOL] Got peer ', peerId.toB58String(), ' | PTI: ', msg.hello.eth.toString())
+        }
+      })
+
       // window.ipfs is available.
       function updateStats () {
         metrics.elapsed = utils.duration(metrics.started)
@@ -111,7 +118,12 @@ export function createIPFSPlayer (templateInstance, currentVideo) {
         window.ipfs.swarm.peers((err, peers) => {
           if (err) throw err
           console.log('-----------------------Peers---------------------------')
+          let msg = paratiiIPFS.protocol.createCommand('test')
           peers.map((peer) => {
+            paratiiIPFS.protocol.network.sendMessage(peer.peer.id, msg, (err) => {
+              if (err) console.error('[Paratii-protocol] Error ', err)
+            })
+
             if (peer.addr) {
               console.log(peer)
             }

--- a/imports/ui/pages/player/ipfs.js
+++ b/imports/ui/pages/player/ipfs.js
@@ -99,7 +99,6 @@ export function createIPFSPlayer (templateInstance, currentVideo) {
     })
 
     paratiiIPFS.initIPFS(() => {
-
       paratiiIPFS.protocol.notifications.on('message:new', (peerId, msg) => {
         if (msg && msg.hello) {
           console.log('[PROTOCOL] Got peer ', peerId.toB58String(), ' | PTI: ', msg.hello.eth.toString())
@@ -121,7 +120,7 @@ export function createIPFSPlayer (templateInstance, currentVideo) {
           let msg = paratiiIPFS.protocol.createCommand('test')
           peers.map((peer) => {
             paratiiIPFS.protocol.network.sendMessage(peer.peer.id, msg, (err) => {
-              if (err) console.error('[Paratii-protocol] Error ', err)
+              if (err) console.warn('[Paratii-protocol] Error ', err)
             })
 
             if (peer.addr) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "meteor-node-stubs": "~0.2.4",
     "moment": "^2.18.1",
     "multihashes": "^0.4.9",
+    "paratii-protocol": "github:ya7ya/paratii-protocol#master",
     "pretty-bytes": "^4.0.2",
     "promisify-node": "^0.4.0",
     "pull-filereader": "^1.0.1",


### PR DESCRIPTION
Hey, This adds the initial needed parts for the [`Paratii-protocol`](https://github.com/ya7ya/paratii-protocol) , Currently it's capable of exchanging commands and responses , plus a status `hello` msg that contains the peer `PTI address`.

This solves a part of issue #103 regarding safe exchange of addresses and other metadata in the future. This is based on `js-ipfs-bitswap` so it can be used as a data exchange protocol later down the line. 