### PR TITLE
Fix profile menu

### DIFF
--- a/imports/ui/stylesheets/account.less
+++ b/imports/ui/stylesheets/account.less
@@ -94,6 +94,8 @@
   transition: all 250ms linear;
   overflow: hidden;
   opacity: 0;
+  z-index: 999;
+  background: @color-white;
 
   &.show {
     max-height: 200px;


### PR DESCRIPTION
Previously, on smaller screen sizes the edit profile menu would not render on top of other content propery 😬 .

![image](https://user-images.githubusercontent.com/7697924/32931332-a59c12d4-cb31-11e7-80f5-350104cdc3be.png)


***


# Now, it does

![image](https://user-images.githubusercontent.com/7697924/32931325-9caca5da-cb31-11e7-83bc-dbe1d81adc51.png)
