### PR TITLE
273 - Improve UX of Inputs (with regards to placeholders)

### DIFF
--- a/imports/ui/components/modals/editProfileInfo.html
+++ b/imports/ui/components/modals/editProfileInfo.html
@@ -10,13 +10,13 @@
           </label>
         </div>
         <div class="name-email-wrapper">
-          <div class="input-group at-input">
+          <div class="input-group">
             <label for="new-username" class="main-form-label">
               Name
             </label>
             <input id="new-username" name="new-username" type="text" class="main-form-input" aria-describedby="sizing-addon1" placeholder="{{currentUser.profile.name}}">
           </div>
-          <div class="input-group at-input">
+          <div class="input-group">
             <label for="new-email" class="main-form-label">
               Email
             </label>

--- a/imports/ui/stylesheets/components/at-modal.less
+++ b/imports/ui/stylesheets/components/at-modal.less
@@ -44,7 +44,7 @@
 .at-input {
   display: block;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 500;
   margin: 0 0 15px;
   position: relative;
   width: 100%;
@@ -70,7 +70,7 @@
     &:-webkit-autofill {
       color: @color-grey;
       font-size: 14px;
-      font-weight: 300;
+      font-weight: 500;
       -webkit-box-shadow: 0 0 0px 1000px white inset;
       -webkit-text-fill-color: @color-grey;
     }
@@ -78,6 +78,7 @@
     &::placeholder {
       color: @color-grey-light;
       -webkit-text-fill-color: @color-grey-light;
+      font-weight: 300;
     }
   }
 

--- a/imports/ui/stylesheets/components/forms/main.less
+++ b/imports/ui/stylesheets/components/forms/main.less
@@ -80,7 +80,7 @@
     &:-webkit-autofill {
       color: @color-grey;
       font-size: 14px;
-      font-weight: 300;
+      font-weight: 500;
       -webkit-box-shadow: 0 0 0px 1000px white inset;
       -webkit-text-fill-color: @color-grey;
 
@@ -97,6 +97,7 @@
     &::placeholder {
       color: @color-grey-light;
       -webkit-text-fill-color: @color-grey-light;
+      font-weight: 300;
     }
 
     &.error {


### PR DESCRIPTION
**Issue**
#273 

**Problem**
On various forms throughout the app, the placeholder text looks exactly like the user's input. This is confusing.

![image](https://user-images.githubusercontent.com/7697924/33079588-04769700-cea4-11e7-9dd0-2ce5492f4f4f.png)


**Fix**
As per @pedrocasa 's suggestion, increase the weight of the user's input to differentiate it from the placeholders.

***

![bold](https://user-images.githubusercontent.com/7697924/33079676-3754ddb2-cea4-11e7-8340-9be91ddb9f68.gif)

***

![boldsign](https://user-images.githubusercontent.com/7697924/33079677-375734ae-cea4-11e7-84b7-6b69c85a6fe5.gif)

