### PR TITLE
[Frontend] main-loader-text weight, mouse leave to close thumb-list-modal and background image on thumbs-list

### DIFF
--- a/imports/ui/components/modals/embedCustomizer.html
+++ b/imports/ui/components/modals/embedCustomizer.html
@@ -37,7 +37,7 @@
           </svg>
         </a>
       </li>
-      <li class="main-modal-share-item">
+      <li class="main-modal-share-item hide-mobile">
         <a class="main-modal-share-link" target="_blank" href="{{ whatsappDesktop }}">
           <svg class="main-modal-share-link-svg">
             <use class="main-modal-share-link-svg-use" xlink:href="#icon-share-whatsapp"></use>

--- a/imports/ui/pages/playlists/playlists.html
+++ b/imports/ui/pages/playlists/playlists.html
@@ -20,11 +20,11 @@
                   </svg>
                 </div>
                 {{#if thumb}}
-                  <div class="thumbs-list-thumb">
+                  <div class="thumbs-list-thumb" style="background-image: url({{ getThumbUrl thumb }});">
                     <img class="thumbs-list-image" src="{{ getThumbUrl thumb }}"/>
                   </div>
                 {{else}}
-                  <div class="thumbs-list-thumb">
+                  <div class="thumbs-list-thumb" style="background-image: url('/img/cover/default-thumb.png');">
                     <img class="thumbs-list-image" src="/img/cover/default-thumb.png"/>
                   </div>
                 {{/if}}
@@ -56,11 +56,11 @@
                   <div class="thumbs-list-price">✓</div>
                 {{/if}}
                 {{#if thumb}}
-                  <div class="thumbs-list-thumb">
+                  <div class="thumbs-list-thumb" style="background-image: url({{ getThumbUrl thumb }});">
                     <img class="thumbs-list-image" src="{{ getThumbUrl thumb }}"/>
                   </div>
                 {{else}}
-                  <div class="thumbs-list-thumb">
+                  <div class="thumbs-list-thumb" style="background-image: url('/img/cover/default-thumb.png');">
                     <img class="thumbs-list-image" src="/img/cover/default-thumb.png"/>
                   </div>
                 {{/if}}

--- a/imports/ui/pages/playlists/playlists.js
+++ b/imports/ui/pages/playlists/playlists.js
@@ -173,5 +173,8 @@ Template.playlists.events({
   },
   'click button.thumbs-list-settings' (event, instance) {
     $(event.currentTarget).closest('.thumbs-list-item').toggleClass('active')
+  },
+  'mouseleave li.thumbs-list-item' (event, instance) {
+    $(event.currentTarget).removeClass('active')
   }
 })

--- a/imports/ui/pages/search/search.html
+++ b/imports/ui/pages/search/search.html
@@ -22,9 +22,13 @@
                   <div class="thumbs-list-price">✓</div>
                 {{/if}}
                 {{#if thumb}}
-                  <div class="thumbs-list-thumb"><img class="thumbs-list-image" src="{{ thumb }}"/></div>
+                  <div class="thumbs-list-thumb" style="background-image: url({{ getThumbUrl thumb }});">
+                    <img class="thumbs-list-image" src="{{ thumb }}"/>
+                  </div>
                 {{else}}
-                  <div class="thumbs-list-thumb"><img class="thumbs-list-image" src="/img/cover/default-thumb.png"/></div>
+                  <div class="thumbs-list-thumb" style="background-image: url('/img/cover/default-thumb.png');">
+                    <img class="thumbs-list-image" src="/img/cover/default-thumb.png"/>
+                  </div>
                 {{/if}}
               </a>
               <div class="thumb-list-modal">

--- a/imports/ui/pages/search/search.js
+++ b/imports/ui/pages/search/search.js
@@ -135,6 +135,13 @@ Template.search.helpers({
     }
     return videoTitle
   },
+  getThumbUrl (thumbSrc) {
+    if (thumbSrc.startsWith('/ipfs/')) {
+      return String('https://gateway.paratii.video' + thumbSrc)
+    } else {
+      return String(thumbSrc)
+    }
+  },
   hasNext () {
     return Template.instance().hasNext.get()
   },

--- a/imports/ui/pages/search/search.js
+++ b/imports/ui/pages/search/search.js
@@ -60,6 +60,9 @@ Template.search.events({
   'click button.thumbs-list-settings' (event, instance) {
     $(event.currentTarget).closest('.thumbs-list-item').toggleClass('active')
   },
+  'mouseleave li.thumbs-list-item' (event, instance) {
+    $(event.currentTarget).removeClass('active')
+  },
   'click .pagenext' () {
     Template.instance().page.set((Template.instance().page.get() + 1))
     FlowRouter.setQueryParams({p: Template.instance().page.get()})

--- a/imports/ui/stylesheets/base/helpers.less
+++ b/imports/ui/stylesheets/base/helpers.less
@@ -42,6 +42,12 @@
 
 // Hide on
 
+.hide-mobile {
+  .mobile & {
+    display: none;
+  }
+}
+
 .only-mobile {
   display: none;
 

--- a/imports/ui/stylesheets/components/lists/thumbs-list.less
+++ b/imports/ui/stylesheets/components/lists/thumbs-list.less
@@ -218,25 +218,24 @@
   &:extend(.pos-a-m all);
 
   backface-visibility: hidden;
+  background: no-repeat 50% 50%;
+  background-size: cover;
   min-height: 100%;
   overflow: hidden;
+  transform: scale(1.05) translate3d(-50%, -50%, 0);
+  transform-origin: left center;
+  transition: transform .75s @ease-smooth;
   width: 100%;
   z-index: 1;
+  
+  .thumbs-list-link:hover & {
+    transform: scale(1.1) translate3d(-50%, -50%, 0);
+    transition: transform .8s @ease-smooth;
+  }
 }
 
 .thumbs-list-image {
-  &:extend(.full-block all);
-
-  height: auto;
-  position: relative;
-  transform: scale(1.05);
-  transition: transform .75s @ease-smooth;
-  z-index: 2;
-
-  .thumbs-list-link:hover & {
-    transform: scale(1.1);
-    transition: transform .8s @ease-smooth;
-  }
+  &:extend(.visually-hidden all);
 }
 
 .thumbs-list-loader {

--- a/imports/ui/stylesheets/components/loaders/main-loader.less
+++ b/imports/ui/stylesheets/components/loaders/main-loader.less
@@ -50,6 +50,7 @@
   &-text {
     color: @color-white-dark;
     font-size: 20px;
+    font-weight: 300;
   }
 
   &-icon {


### PR DESCRIPTION
-  Set `font-weight: 300` to `.main-loader-text`
- Close `.thumb-list-modal`  when mouse leaves the `.li.thumbs-list-item`(suggested by @pedrocasa)
- Close issue "Sharing: whatsapp desktop and whatsapp mobile #321" 