### PR TITLE
315 - spacebar play pause

### DIFF
--- a/imports/ui/pages/player/player.html
+++ b/imports/ui/pages/player/player.html
@@ -1,5 +1,5 @@
 <template name="player">
-  <div id="player-container" class="player-container {{ hideControls }} {{ descriptionClass }} {{ mutedClass }} {{ volumeClass }} {{ playPause }}">
+  <div id="player-container" class="player-container {{ hideControls }} {{ descriptionClass }} {{ mutedClass }} {{ volumeClass }} {{ playPause }}" tabIndex=99>
 
     {{currentVideo}}
 

--- a/imports/ui/pages/player/player.js
+++ b/imports/ui/pages/player/player.js
@@ -144,6 +144,10 @@ Template.player.onCreated(function () {
   })
 })
 
+Template.player.onDestroyed(function () {
+  Meteor.clearTimeout(controlsHandler)
+})
+
 Template.player.onRendered(function () {
   const container = this.find('#player-container')
   if (container) {

--- a/imports/ui/pages/player/player.js
+++ b/imports/ui/pages/player/player.js
@@ -549,6 +549,7 @@ Template.player.events({
   'keydown #player-container' (event, instance) {
     // Space key
     if (event.keyCode === 32) {
+      event.preventDefault()
       const dict = instance.playerState
       if (dict.get('playing')) {
         pauseVideo(instance)

--- a/imports/ui/pages/player/player.js
+++ b/imports/ui/pages/player/player.js
@@ -96,6 +96,15 @@ Template.player.onCreated(function () {
   // Description
   this.playerState.set('showDescription', false)
 
+  this.togglePlay = () => {
+    const dict = this.playerState
+    if (dict.get('playing')) {
+      pauseVideo(instance)
+    } else {
+      playVideo(instance)
+    }
+  }
+
   log('navState:', this.navState.get())
 
   /* DETERMINED IF PLAYER IS EMBEDED */
@@ -373,12 +382,7 @@ Template.player.events({
     navState.set('minimized')
   },
   'click #play-pause-button' (event, instance) {
-    const dict = instance.playerState
-    if (dict.get('playing')) {
-      pauseVideo(instance)
-    } else {
-      playVideo(instance)
-    }
+    instance.togglePlay(instance)
   },
   'click #next-video-button' () {
     const playlistId = FlowRouter.getQueryParam('playlist')
@@ -550,12 +554,7 @@ Template.player.events({
     // Space key
     if (event.keyCode === 32) {
       event.preventDefault()
-      const dict = instance.playerState
-      if (dict.get('playing')) {
-        pauseVideo(instance)
-      } else {
-        playVideo(instance)
-      }
+      instance.togglePlay(instance)
     }
   }
 })

--- a/imports/ui/pages/player/player.js
+++ b/imports/ui/pages/player/player.js
@@ -135,8 +135,11 @@ Template.player.onCreated(function () {
   })
 })
 
-Template.player.onDestroyed(function () {
-  Meteor.clearTimeout(controlsHandler)
+Template.player.onRendered(function () {
+  const container = this.find('#player-container')
+  if (container) {
+    container.focus()
+  }
 })
 
 Template.player.helpers({
@@ -542,5 +545,16 @@ Template.player.events({
   },
   'click button.thumbs-list-settings' (event, instance) {
     $(event.currentTarget).parent().toggleClass('active')
+  },
+  'keydown #player-container' (event, instance) {
+    // Space key
+    if (event.keyCode === 32) {
+      const dict = instance.playerState
+      if (dict.get('playing')) {
+        pauseVideo(instance)
+      } else {
+        playVideo(instance)
+      }
+    }
   }
 })

--- a/tests/player.test.js
+++ b/tests/player.test.js
@@ -151,6 +151,7 @@ describe('Player:', function () {
 
     assert.equal(browser.execute(playerIsFullScreen).value, true)
 
+    browser.switchTab()
     browser.keys('Space')
 
     browser.waitUntil(() => browser.getAttribute('#video-player', 'paused') === 'true')

--- a/tests/player.test.js
+++ b/tests/player.test.js
@@ -1,7 +1,24 @@
 import { assert } from 'chai'
 import { assertUserIsLoggedIn, assertUserIsNotLoggedIn, createUserAndLogin, createPlaylist, createVideo } from './helpers.js'
 
+const playerIsFullScreen = () => !!(
+  document.fullscreenElement ||
+  document.mozFullScreenElement ||
+  document.webkitFullscreenElement ||
+  document.msFullscreenElement
+)
+
 describe('Player:', function () {
+  before(function () {
+    browser.addCommand('waitUntilVideoIsPlaying', () => {
+      browser.waitUntil(() => (
+        parseInt(browser.getAttribute('#video-player', 'currentTime'), 10) !== 0 &&
+        browser.getAttribute('#video-player', 'paused') !== 'true' &&
+        browser.getAttribute('#video-player', 'ended') !== 'true'
+      ))
+    })
+  })
+
   beforeEach(function () {
     server.execute(createVideo, '12345', 'Test 1', '', '', [''], 0)
     server.execute(createVideo, '23456', 'Test 2', '', '', [''], 0)
@@ -65,7 +82,7 @@ describe('Player:', function () {
   it('if a player is not within a playlist and it ended related videos show up [TODO]', () => {
   })
 
-  it('like and dislike a video as an anonymous user @watch', () => {
+  it('like and dislike a video as an anonymous user', () => {
     assertUserIsNotLoggedIn(browser)
     browser.url('http://localhost:3000/play/12345?playlist=98765')
     browser.waitForClickable('#button-like')
@@ -109,5 +126,37 @@ describe('Player:', function () {
     })
     assert.equal(browser.getText('#button-like'), '')
     assert.equal(browser.getText('#button-dislike'), '1')
+  })
+
+  it('should play/pause a video when the spacebar is pressed', () => {
+    browser.url('http://localhost:3000/play/12345?playlist=98765')
+    browser.waitForClickable('#play-pause-button')
+    browser.switchTab()
+    browser.waitUntil(() => browser.hasFocus('#player-container'))
+    browser.keys('Space')
+
+    browser.waitUntilVideoIsPlaying()
+
+    browser.keys('Space')
+
+    browser.waitUntil(() => browser.getAttribute('#video-player', 'paused') === 'true')
+  })
+
+  it('should stay in full-screen mode when a video is paused via the space bar', () => {
+    browser.url('http://localhost:3000/play/12345?playlist=98765')
+    browser.waitAndClick('#play-pause-button')
+    browser.waitUntilVideoIsPlaying()
+
+    browser.waitAndClick('#fullscreen-button')
+
+    assert.equal(browser.execute(playerIsFullScreen).value, true)
+
+    browser.keys('Space')
+
+    browser.waitUntil(() => browser.getAttribute('#video-player', 'paused') === 'true')
+
+    assert.equal(browser.execute(playerIsFullScreen).value, true)
+
+    browser.waitAndClick('#fullscreen-button')
   })
 })


### PR DESCRIPTION
**Issue**
#315 

**Problem**
Users cannot reliably play/pause their current video by pressing the spacebar. This functionality exists in most video players and would come across as a missing feature.

**Work Done**
- Allow player container to be focused
- Have player controller toggle play state when it receives a spacebar keydown event