### PR TITLE
Moved .player-share and some fixes

### DIFF
--- a/client/main.less
+++ b/client/main.less
@@ -46,7 +46,6 @@
 @import "{}/imports/ui/stylesheets/modal/main.less";
 @import "{}/imports/ui/stylesheets/modal/sign.less";
 @import "{}/imports/ui/stylesheets/modal/unlock.less";
-@import "{}/imports/ui/stylesheets/modal/share.less";
 @import "{}/imports/ui/stylesheets/modal/playlist.less";
 @import "{}/imports/ui/stylesheets/modal/receive.less";
 @import "{}/imports/ui/stylesheets/modal/updateuser.less";

--- a/client/main.less
+++ b/client/main.less
@@ -39,13 +39,13 @@
 @import "{}/imports/ui/stylesheets/player/video.less";
 @import "{}/imports/ui/stylesheets/player/controls.less";
 @import "{}/imports/ui/stylesheets/player/infos.less";
-@import "{}/imports/ui/stylesheets/player/share.less";
 
 // Modal
 
 @import "{}/imports/ui/stylesheets/modal/main.less";
 @import "{}/imports/ui/stylesheets/modal/sign.less";
 @import "{}/imports/ui/stylesheets/modal/unlock.less";
+@import "{}/imports/ui/stylesheets/modal/share.less";
 @import "{}/imports/ui/stylesheets/modal/playlist.less";
 @import "{}/imports/ui/stylesheets/modal/receive.less";
 @import "{}/imports/ui/stylesheets/modal/updateuser.less";

--- a/imports/ui/pages/player/player.html
+++ b/imports/ui/pages/player/player.html
@@ -106,6 +106,13 @@
                   </svg>
                   {{formatNumber stats.dislikes}}
                 </button>
+
+
+                <button id="embed" data-title="{{title}}" class="player-stats-item ">
+                  <svg class="player-stats-icon">
+                    <use class="player-stats-icon-use" xlink:href="#icon-share"></use>
+                  </svg>
+                </button>
               </div>
               {{#if description}}
               <button class="button-text nocase white player-infos-button-description" type="button">{{_ "Show description" }}</button>
@@ -158,26 +165,6 @@
               </button>
             {{/if}}
           </div>
-        </div>
-        <div class="player-share">
-          <button class="player-share-button player-share-button-add">
-            <svg class="player-share-button-icon">
-              <use class="player-share-button-icon-use" xlink:href="#icon-playlists-add"></use>
-            </svg>
-          </button>
-          <button id="embed" data-title="{{title}}" class="player-share-button player-share-button-share">
-            <svg class="player-share-button-icon">
-              <use class="player-share-button-icon-use" xlink:href="#icon-share"></use>
-            </svg>
-          </button>
-          <button class="player-share-button player-share-button-later active">
-            <svg class="player-share-button-icon player-share-button-later-watch">
-              <use class="player-share-button-icon-use" xlink:href="#icon-watch-later"></use>
-            </svg>
-            <svg class="player-share-button-icon player-share-button-later-add">
-              <use class="player-share-button-icon-use" xlink:href="#icon-watch-later-add"></use>
-            </svg>
-          </button>
         </div>
       </div>
     {{/with}}

--- a/imports/ui/stylesheets/components/loaders/main-loader.less
+++ b/imports/ui/stylesheets/components/loaders/main-loader.less
@@ -35,6 +35,7 @@
   &-content {
     left: 30px;
     margin: 0 0 40px;
+    max-width: 80%;
     opacity: 0;
     transform: translateY(20px);
     transition: opacity .35s linear .25s, transform .7s @ease-smooth .2s; 
@@ -58,11 +59,20 @@
     font-weight: 300;
     text-align: center;
     padding: 0 20px;
+
+    .query-mini({
+      font-size: 18px;
+    });
   }
 
   &-icon {
     margin: 20px auto 0;
     width: 60px;
+
+    .query-mini({
+      margin-top: 15px;
+      width: 50px;
+    });
   }
 
   &-svg {

--- a/imports/ui/stylesheets/internals/main.less
+++ b/imports/ui/stylesheets/internals/main.less
@@ -20,7 +20,7 @@
     &-label,
     &-title {
       animation: showFromLeft .75s @ease-smooth forwards;
-      margin-right: 40px;
+      margin-right: 65px;
     }
 
     &-input,

--- a/imports/ui/stylesheets/player/share.less
+++ b/imports/ui/stylesheets/player/share.less
@@ -40,7 +40,6 @@
     }
 
     &-add {
-      display: none;
       height: 15px;
     }
 
@@ -49,7 +48,6 @@
     }
 
     &-later {
-      display: none;
       height: 20px;
 
       &-watch {


### PR DESCRIPTION
- For now, the `.player-share` removed and the button share moved to `.player-stats`.
- The `internals-header-title` `margin-right` increased to avoid collision with settings button.
- The main-loader margin and text-size changed on mini.